### PR TITLE
test(infra): align repository tests with new domain/context APIs

### DIFF
--- a/backend/internal/domain/status_test.go
+++ b/backend/internal/domain/status_test.go
@@ -46,7 +46,9 @@ func TestStatusName_Constants(t *testing.T) {
 }
 
 func TestStatusName_Equals(t *testing.T) {
-	assert.True(t, domain.StatusNameTodo.Equals(domain.StatusNameTodo))
+	todo, err := domain.NewStatusName("todo")
+	assert.NoError(t, err)
+	assert.True(t, domain.StatusNameTodo.Equals(todo))
 	assert.False(t, domain.StatusNameTodo.Equals(domain.StatusNameDone))
 }
 

--- a/backend/internal/domain/user_test.go
+++ b/backend/internal/domain/user_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"backend/internal/domain"
-	"backend/pkg"
+	"backend/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -55,7 +55,7 @@ func TestNewUser(t *testing.T) {
 }
 
 func TestReconstructUser(t *testing.T) {
-	now := pkg.Str2time("2025-01-01")
+	now := testutil.MustDate(t, "2025-01-01")
 	email := validEmail(t)
 	hashed := validHashedPassword(t)
 

--- a/backend/internal/infra/db/status_test.go
+++ b/backend/internal/infra/db/status_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"context"
 	"testing"
 
 	"backend/internal/domain"
@@ -22,77 +23,36 @@ func TestStatusRepositorySuite(t *testing.T) {
 
 func (suite *StatusRepositorySuite) SetupSuite() {
 	suite.DBSQLiteSuite.SetupSuite()
-	suite.sr = db.NewStatusRepository(suite.DB)
+	suite.sr = db.NewStatusRepository(db.NewBaseRepository(suite.DB))
 }
 
 func (suite *StatusRepositorySuite) TestStatus() {
-	paramStatus, err := domain.NewStatus("todo")
-	expectedID := domain.StatusID(1)
-	expectedName := domain.StatusName("todo")
-	suite.Assert().Nil(err)
-	status, err := suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		id   domain.StatusID
+	}{
+		{"todo", 1},
+		{"inProgress", 2},
+		{"done", 3},
+		{"archive", 4},
+		{"pending", 5},
+	}
 
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
+	for _, c := range cases {
+		paramStatus, err := domain.NewStatus(c.name)
+		suite.Assert().Nil(err)
+		expectedName, err := domain.NewStatusName(c.name)
+		suite.Assert().Nil(err)
 
-	paramStatus, err = domain.NewStatus("inProgress")
-	expectedID = domain.StatusID(2)
-	expectedName = domain.StatusName("inProgress")
-	suite.Assert().Nil(err)
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
+		status, err := suite.sr.GetOrCreate(ctx, &paramStatus)
+		suite.Assert().Nil(err)
+		suite.Assert().Equal(c.id, status.ID)
+		suite.Assert().True(expectedName.Equals(status.Name))
 
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
-
-	paramStatus, err = domain.NewStatus("done")
-	expectedID = domain.StatusID(3)
-	expectedName = domain.StatusName("done")
-	suite.Assert().Nil(err)
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
-
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
-
-	paramStatus, err = domain.NewStatus("archive")
-	expectedID = domain.StatusID(4)
-	expectedName = domain.StatusName("archive")
-	suite.Assert().Nil(err)
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
-
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
-
-	paramStatus, err = domain.NewStatus("pending")
-	expectedID = domain.StatusID(5)
-	expectedName = domain.StatusName("pending")
-	suite.Assert().Nil(err)
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
-
-	status, err = suite.sr.GetOrCreate(paramStatus)
-	suite.Assert().Nil(err)
-	suite.Assert().Equal(expectedID, status.ID)
-	suite.Assert().Equal(expectedName, status.Name)
+		status, err = suite.sr.GetOrCreate(ctx, &paramStatus)
+		suite.Assert().Nil(err)
+		suite.Assert().Equal(c.id, status.ID)
+		suite.Assert().True(expectedName.Equals(status.Name))
+	}
 }

--- a/backend/internal/infra/db/task_test.go
+++ b/backend/internal/infra/db/task_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"strings"
@@ -19,6 +20,7 @@ type TaskRepositorySuite struct {
 	testutil.DBSQLiteSuite
 	tr repository.TaskRepository
 	ur repository.UserRepository
+	sr repository.StatusRepository
 }
 
 func TestTaskRepositorySuite(t *testing.T) {
@@ -27,122 +29,124 @@ func TestTaskRepositorySuite(t *testing.T) {
 
 func (suite *TaskRepositorySuite) SetupSuite() {
 	suite.DBSQLiteSuite.SetupSuite()
-	suite.tr = db.NewTaskRepository(suite.DB)
-	suite.ur = db.NewUserRepository(suite.DB)
+	suite.tr = db.NewTaskRepository(db.NewBaseRepository(suite.DB))
+	suite.ur = db.NewUserRepository(db.NewBaseRepository(suite.DB))
+	suite.sr = db.NewStatusRepository(db.NewBaseRepository(suite.DB))
 }
 
 func (suite *TaskRepositorySuite) MockDB() sqlmock.Sqlmock {
 	mock, mockGormDB := testutil.MockDB()
-	suite.tr = db.NewTaskRepository(mockGormDB)
-	suite.ur = db.NewUserRepository(mockGormDB)
+	suite.tr = db.NewTaskRepository(db.NewBaseRepository(mockGormDB))
+	suite.ur = db.NewUserRepository(db.NewBaseRepository(mockGormDB))
+	suite.sr = db.NewStatusRepository(db.NewBaseRepository(mockGormDB))
 	return mock
 }
 
 func (suite *TaskRepositorySuite) AfterTest(suiteName, testName string) {
-	suite.tr = db.NewTaskRepository(suite.DB)
-	suite.ur = db.NewUserRepository(suite.DB)
+	suite.tr = db.NewTaskRepository(db.NewBaseRepository(suite.DB))
+	suite.ur = db.NewUserRepository(db.NewBaseRepository(suite.DB))
+	suite.sr = db.NewStatusRepository(db.NewBaseRepository(suite.DB))
+}
+
+func (suite *TaskRepositorySuite) buildUser(emailStr string) *domain.User {
+	email, err := domain.NewEmail(emailStr)
+	suite.Require().Nil(err)
+	plain, err := domain.NewPlainPassword("password123")
+	suite.Require().Nil(err)
+	hashed, err := plain.Hash()
+	suite.Require().Nil(err)
+	user, err := domain.NewUser(email, hashed)
+	suite.Require().Nil(err)
+	return user
 }
 
 func (suite *TaskRepositorySuite) TestTaskRepositoryCRUD() {
-	user := &domain.User{
-		ID:    1,
-		Email: "test@test.com",
-	}
+	ctx := context.Background()
 
-	user, _ = suite.ur.Create(user)
-
-	task := &domain.Task{
-		Name:   "test",
-		Status: domain.Status{Name: domain.StatusName("todo")},
-		User:   *user,
-	}
-
-	// test create
-	task, err := suite.tr.Create(task)
+	user, err := suite.ur.Create(ctx, suite.buildUser("test@test.com"))
 	suite.Assert().Nil(err)
-	suite.Assert().NotZero(task.ID)
-	suite.Assert().Equal("test", task.Name)
-	suite.Assert().NotZero(task.Status.ID)
-	suite.Assert().Equal(domain.StatusName("todo"), task.Status.Name)
-	suite.Assert().NotZero(task.User.ID)
-	suite.Assert().Equal("test@test.com", task.User.Email)
 
-	// test get
-	getTask, err := suite.tr.Get(task.ID, user.ID)
+	statusParam, err := domain.NewStatus("todo")
 	suite.Assert().Nil(err)
-	suite.Assert().Equal("test", getTask.Name)
-	suite.Assert().NotZero(getTask.Status.ID)
-	suite.Assert().Equal(domain.StatusName("todo"), getTask.Status.Name)
-
-	// test get all
-	// getTasks, err := suite.tr.GetAll()
-
-	// test save
-	getTask.Name = "updated"
-	updatedTask, err := suite.tr.Save(getTask)
+	resolvedStatus, err := suite.sr.GetOrCreate(ctx, &statusParam)
 	suite.Assert().Nil(err)
-	suite.Assert().Equal("updated", updatedTask.Name)
-	suite.Assert().NotZero(updatedTask.Status.ID)
-	suite.Assert().Equal(domain.StatusName("todo"), updatedTask.Status.Name)
 
-	// test delete
-	err = suite.tr.Delete(updatedTask.ID, updatedTask.UserID)
+	taskName, err := domain.NewTaskName("test")
 	suite.Assert().Nil(err)
-	deletedTask, err := suite.tr.Get(updatedTask.ID, updatedTask.UserID)
-	suite.Assert().Nil(deletedTask)
-	suite.Assert().True(strings.Contains("record not found", err.Error()))
+	task, err := domain.NewTask(taskName, *resolvedStatus, user.ID(), nil)
+	suite.Assert().Nil(err)
+
+	created, err := suite.tr.Create(ctx, task)
+	suite.Assert().Nil(err)
+	suite.Assert().NotZero(created.ID())
+	suite.Assert().Equal("test", created.Name().String())
+	suite.Assert().NotZero(created.Status().ID)
+	suite.Assert().Equal("todo", created.Status().Name.String())
+	suite.Assert().Equal(user.ID(), created.UserID())
+
+	got, err := suite.tr.Get(ctx, created.ID(), user.ID())
+	suite.Assert().Nil(err)
+	suite.Assert().Equal("test", got.Name().String())
+	suite.Assert().NotZero(got.Status().ID)
+	suite.Assert().Equal("todo", got.Status().Name.String())
+
+	updatedName, err := domain.NewTaskName("updated")
+	suite.Assert().Nil(err)
+	updatedTask := domain.ReconstructTask(got.ID(), updatedName, got.Status(), got.UserID(), got.Deadline())
+	updated, err := suite.tr.Save(ctx, updatedTask)
+	suite.Assert().Nil(err)
+	suite.Assert().Equal("updated", updated.Name().String())
+	suite.Assert().NotZero(updated.Status().ID)
+	suite.Assert().Equal("todo", updated.Status().Name.String())
+
+	err = suite.tr.Delete(ctx, updated.ID(), updated.UserID())
+	suite.Assert().Nil(err)
+	deleted, err := suite.tr.Get(ctx, updated.ID(), updated.UserID())
+	suite.Assert().Nil(deleted)
+	suite.Assert().True(strings.Contains(err.Error(), "record not found"))
 }
 
 func (suite *TaskRepositorySuite) TestTaskCreateFailure() {
 	mockDB := suite.MockDB()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "statuses" WHERE "statuses"."name" = $1 ORDER BY "statuses"."id" LIMIT $2`)).WithArgs("todo", 1).WillReturnError(errors.New("create error"))
+	mockDB.ExpectBegin()
+	mockDB.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "tasks"`)).
+		WillReturnError(errors.New("create error"))
+	mockDB.ExpectRollback()
 
-	task := &domain.Task{
-		Name:   "test",
-		Status: domain.Status{Name: domain.StatusName("todo")},
-	}
+	taskName, err := domain.NewTaskName("test")
+	suite.Assert().Nil(err)
+	statusName, err := domain.NewStatusName("todo")
+	suite.Assert().Nil(err)
+	task, err := domain.NewTask(taskName, domain.Status{ID: 1, Name: statusName}, 1, nil)
+	suite.Assert().Nil(err)
 
-	createdTask, err := suite.tr.Create(task)
-	suite.Assert().Nil(createdTask)
+	created, err := suite.tr.Create(context.Background(), task)
+	suite.Assert().Nil(created)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("create error", err.Error())
 }
 
 func (suite *TaskRepositorySuite) TestTaskGetFailure() {
 	mockDB := suite.MockDB()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "tasks" WHERE id = $1 AND user_id = $2 ORDER BY "tasks"."id" LIMIT $3`)).WithArgs(1, 1, 1).WillReturnError(errors.New("get error"))
+	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "tasks" WHERE id = $1 AND user_id = $2 ORDER BY "tasks"."id" LIMIT $3`)).
+		WithArgs(1, 1, 1).
+		WillReturnError(errors.New("get error"))
 
-	task, err := suite.tr.Get(1, 1)
+	task, err := suite.tr.Get(context.Background(), 1, 1)
 	suite.Assert().Nil(task)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("get error", err.Error())
 }
 
-func (suite *TaskRepositorySuite) TestTaskSaveFailure() {
-	mockDB := suite.MockDB()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "tasks" WHERE id = $1 AND user_id = $2 ORDER BY "tasks"."id" LIMIT $3`)).WithArgs(1, 1, 1).WillReturnError(errors.New("save error"))
-
-	task := &domain.Task{
-		ID:     1,
-		Name:   "test",
-		Status: domain.Status{Name: domain.StatusName("todo")},
-		UserID: 1,
-	}
-
-	task, err := suite.tr.Save(task)
-	suite.Assert().Nil(task)
-	suite.Assert().NotNil(err)
-	suite.Assert().Equal("save error", err.Error())
-}
-
 func (suite *TaskRepositorySuite) TestTaskDeleteFailure() {
 	mockDB := suite.MockDB()
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec(regexp.QuoteMeta(`DELETE FROM "tasks" WHERE id = $1 AND user_id = $2`)).WithArgs(1, 1).WillReturnError(errors.New("delete error"))
+	mockDB.ExpectExec(regexp.QuoteMeta(`DELETE FROM "tasks" WHERE id = $1 AND user_id = $2`)).
+		WithArgs(1, 1).
+		WillReturnError(errors.New("delete error"))
 	mockDB.ExpectRollback()
-	mockDB.ExpectCommit()
 
-	err := suite.tr.Delete(1, 1)
+	err := suite.tr.Delete(context.Background(), 1, 1)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("delete error", err.Error())
 }

--- a/backend/internal/infra/db/user_test.go
+++ b/backend/internal/infra/db/user_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"backend/internal/domain/repository"
 	"backend/internal/infra/db"
 	"backend/internal/testutil"
-	"backend/pkg"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/suite"
@@ -27,76 +27,83 @@ func TestUserRepositorySuite(t *testing.T) {
 
 func (suite *UserRepositorySuite) SetupSuite() {
 	suite.DBSQLiteSuite.SetupSuite()
-	suite.ur = db.NewUserRepository(suite.DB)
+	suite.ur = db.NewUserRepository(db.NewBaseRepository(suite.DB))
 }
 
 func (suite *UserRepositorySuite) MockDB() sqlmock.Sqlmock {
 	mock, mockGormDB := testutil.MockDB()
-	suite.ur = db.NewUserRepository(mockGormDB)
+	suite.ur = db.NewUserRepository(db.NewBaseRepository(mockGormDB))
 	return mock
 }
 
 func (suite *UserRepositorySuite) AfterTest(suiteName, testName string) {
-	suite.ur = db.NewUserRepository(suite.DB)
+	suite.ur = db.NewUserRepository(db.NewBaseRepository(suite.DB))
+}
+
+func (suite *UserRepositorySuite) buildUser(emailStr string) *domain.User {
+	email, err := domain.NewEmail(emailStr)
+	suite.Require().Nil(err)
+	plain, err := domain.NewPlainPassword("password123")
+	suite.Require().Nil(err)
+	hashed, err := plain.Hash()
+	suite.Require().Nil(err)
+	user, err := domain.NewUser(email, hashed)
+	suite.Require().Nil(err)
+	return user
 }
 
 func (suite *UserRepositorySuite) TestUserRepositoryCRUD() {
-	now := pkg.Str2time("2025-01-01")
-	user := &domain.User{
-		Email:     "test@test.com",
-		CreatedAt: now,
-	}
-	user, err := suite.ur.Create(user)
-	suite.Assert().Nil(err)
-	suite.Assert().NotZero(user.ID)
-	suite.Assert().Equal("test@test.com", user.Email)
-	suite.Assert().Equal(now, user.CreatedAt)
+	ctx := context.Background()
+	user := suite.buildUser("test@test.com")
 
-	getUser, err := suite.ur.Get(user.ID)
+	created, err := suite.ur.Create(ctx, user)
 	suite.Assert().Nil(err)
-	suite.Assert().Equal("test@test.com", getUser.Email)
-	suite.Assert().Equal(now, getUser.CreatedAt)
+	suite.Assert().NotZero(created.ID())
+	suite.Assert().Equal("test@test.com", created.Email().String())
 
-	getUser, err = suite.ur.GetByEmail(user.Email)
+	got, err := suite.ur.Get(ctx, created.ID())
 	suite.Assert().Nil(err)
-	suite.Assert().Equal("test@test.com", getUser.Email)
-	suite.Assert().Equal(now, getUser.CreatedAt)
+	suite.Assert().Equal("test@test.com", got.Email().String())
 
-	getUser.Email = "updated@updated.com"
-	updatedUser, err := suite.ur.Save(getUser)
+	got, err = suite.ur.GetByEmail(ctx, created.Email().String())
 	suite.Assert().Nil(err)
-	suite.Assert().Equal("updated@updated.com", updatedUser.Email)
+	suite.Assert().Equal("test@test.com", got.Email().String())
 
-	err = suite.ur.Delete(updatedUser.ID)
+	updatedEmail, err := domain.NewEmail("updated@updated.com")
 	suite.Assert().Nil(err)
-	deletedUser, err := suite.ur.Get(updatedUser.ID)
-	suite.Assert().Nil(deletedUser)
-	suite.Assert().True(strings.Contains("record not found", err.Error()))
+	reUser := domain.ReconstructUser(got.ID(), updatedEmail, got.Password(), got.CreatedAt())
+	updated, err := suite.ur.Save(ctx, reUser)
+	suite.Assert().Nil(err)
+	suite.Assert().Equal("updated@updated.com", updated.Email().String())
+
+	err = suite.ur.Delete(ctx, updated.ID())
+	suite.Assert().Nil(err)
+	deleted, err := suite.ur.Get(ctx, updated.ID())
+	suite.Assert().Nil(deleted)
+	suite.Assert().True(strings.Contains(err.Error(), "record not found"))
 }
 
 func (suite *UserRepositorySuite) TestUserCreateFailure() {
 	mockDB := suite.MockDB()
 	mockDB.ExpectBegin()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "users" ("email","password","created_at") VALUES ($1,$2,$3) RETURNING "id"`)).
-		WithArgs("test@test.com", "", sqlmock.AnyArg()).
+	mockDB.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "users"`)).
 		WillReturnError(errors.New("create error"))
 	mockDB.ExpectRollback()
 
-	user := &domain.User{
-		Email: "test@test.com",
-	}
-
-	createdUser, err := suite.ur.Create(user)
-	suite.Assert().Nil(createdUser)
+	user := suite.buildUser("test@test.com")
+	created, err := suite.ur.Create(context.Background(), user)
+	suite.Assert().Nil(created)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("create error", err.Error())
 }
 
 func (suite *UserRepositorySuite) TestUserGetFailure() {
 	mockDB := suite.MockDB()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" LIMIT $2`)).WithArgs(1, 1).WillReturnError(errors.New("get error"))
+	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" LIMIT $2`)).
+		WithArgs(1, 1).
+		WillReturnError(errors.New("get error"))
 
-	user, err := suite.ur.Get(1)
+	user, err := suite.ur.Get(context.Background(), 1)
 	suite.Assert().Nil(user)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("get error", err.Error())
@@ -104,37 +111,25 @@ func (suite *UserRepositorySuite) TestUserGetFailure() {
 
 func (suite *UserRepositorySuite) TestUserGetByEmail() {
 	mockDB := suite.MockDB()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE email = $1 ORDER BY "users"."id" LIMIT $2`)).WithArgs("test@test.com", 1).WillReturnError(errors.New("get by email error"))
+	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE email = $1 ORDER BY "users"."id" LIMIT $2`)).
+		WithArgs("test@test.com", 1).
+		WillReturnError(errors.New("get by email error"))
 
-	user, err := suite.ur.GetByEmail("test@test.com")
+	user, err := suite.ur.GetByEmail(context.Background(), "test@test.com")
 	suite.Assert().Nil(user)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("get by email error", err.Error())
 }
 
-func (suite *UserRepositorySuite) TestUserSaveFailure() {
-	mockDB := suite.MockDB()
-	mockDB.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" LIMIT $2`)).WithArgs(1, 1).WillReturnError(errors.New("save error"))
-
-	user := &domain.User{
-		ID:    1,
-		Email: "test@test.com",
-	}
-
-	user, err := suite.ur.Save(user)
-	suite.Assert().Nil(user)
-	suite.Assert().NotNil(err)
-	suite.Assert().Equal("save error", err.Error())
-}
-
 func (suite *UserRepositorySuite) TestUserDeleteFailure() {
 	mockDB := suite.MockDB()
 	mockDB.ExpectBegin()
-	mockDB.ExpectExec(regexp.QuoteMeta(`DELETE FROM "users" WHERE "users"."id" = $1`)).WithArgs(1).WillReturnError(errors.New("delete error"))
+	mockDB.ExpectExec(regexp.QuoteMeta(`DELETE FROM "users" WHERE "users"."id" = $1`)).
+		WithArgs(1).
+		WillReturnError(errors.New("delete error"))
 	mockDB.ExpectRollback()
-	mockDB.ExpectCommit()
 
-	err := suite.ur.Delete(1)
+	err := suite.ur.Delete(context.Background(), 1)
 	suite.Assert().NotNil(err)
 	suite.Assert().Equal("delete error", err.Error())
 }

--- a/backend/internal/infra/web/gin/handler/user_test.go
+++ b/backend/internal/infra/web/gin/handler/user_test.go
@@ -49,7 +49,7 @@ func (m *MockUserUseCase) Delete(ctx context.Context, userID domain.UserID) erro
 
 type UserHandlerSuite struct {
 	suite.Suite
-	uh UserHandler
+	// uh UserHandler
 }
 
 func TestUserHandlerTestSuite(t *testing.T) {

--- a/backend/internal/infra/web/gin/router/router.go
+++ b/backend/internal/infra/web/gin/router/router.go
@@ -29,7 +29,10 @@ func setupSwagger(router *gin.Engine) (*openapi3.T, error) {
 
 	env := pkg.GetEnvDefault("APP_ENV", "development")
 	if env == "development" {
-		swaggerJson, _ := json.Marshal(swagger)
+		swaggerJson, err := json.Marshal(swagger)
+		if err != nil {
+			return nil, err
+		}
 		var SwaggerInfo = &swag.Spec{
 			InfoInstanceName: "swagger",
 			SwaggerTemplate:  string(swaggerJson),

--- a/backend/internal/testutil/time.go
+++ b/backend/internal/testutil/time.go
@@ -1,0 +1,15 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func MustDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02", s)
+	require.NoError(t, err)
+	return parsed
+}

--- a/backend/pkg/networks.go
+++ b/backend/pkg/networks.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -15,8 +14,14 @@ func GetEndpoint(path string) string {
 	if env == "stage" {
 		baseURL = "http://stage.localhost:8080"
 	}
-	p, _ := url.Parse(path)
-	b, _ := url.Parse(baseURL)
+	p, err := url.Parse(path)
+	if err != nil {
+		return ""
+	}
+	b, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
 	return b.ResolveReference(p).String()
 }
 
@@ -32,7 +37,7 @@ func WaitForPort(host, port string, timeout time.Duration) bool {
 }
 
 func CheckPort(host, port string) bool {
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", host, port))
+	conn, err := net.Dial("tcp", net.JoinHostPort(host, port))
 	if conn != nil {
 		conn.Close()
 		return false

--- a/backend/pkg/utils.go
+++ b/backend/pkg/utils.go
@@ -2,13 +2,7 @@ package pkg
 
 import (
 	"os"
-	"time"
 )
-
-func Str2time(t string) time.Time {
-	parsedTime, _ := time.Parse("2006-01-02", t)
-	return parsedTime
-}
 
 func GetEnvDefault(key, defVal string) string {
 	val, err := os.LookupEnv(key)


### PR DESCRIPTION
Update infra/db tests for context-aware repository signatures and value-object based domain constructors. Refactor StatusRepository test into a table-driven loop and drop Save failure cases that no longer match the current SQL flow.

## 概要
<!-- PRの背景と変更内容を簡潔に -->

## 対応したチケット
<!-- Link to GitHub Issue -->
close #28 

## やったこと
<!-- このPRでやったことを具体的に -->
-

## やらないこと
<!-- このPRでやらないことはなにか -->
-

## 影響範囲
<!-- 影響を及ぼす範囲や他の機能への影響 -->
-

## テスト
<!-- テスト方法や結果 -->
-

## レビュー時の注意点
-

## その他
<!-- 自分の学習ログや、参考リンクなどにご活用ください -->
